### PR TITLE
Issue #119 update to ens3 for Ubuntu 16 on AWS

### DIFF
--- a/usr/lib/arc/create/setup_dhcp
+++ b/usr/lib/arc/create/setup_dhcp
@@ -78,7 +78,12 @@ function setup_dhcp() {
       service network restart
     fi
   else
-    ifdown eth0 && ifup eth0
+    MAJOR_VERSION=$(echo $VERSION_ID | tr "." "\n" | head -n 1)
+    if [[ $ID = "ubuntu" && $MAJOR_VERSION == "16" ]]; then
+      ifdown ens3 && ifup ens3
+    else 
+      ifdown eth0 && ifup eth0
+    fi
   fi
 }
 


### PR DESCRIPTION
In moving to Ubuntu 16 on AWS, the network interface has changed to ens3.   Other OS (Centos/prior Ubuntu versions) retain the original functionality.